### PR TITLE
reconfigure workspace to enable changesets for data parsers

### DIFF
--- a/.changeset/late-chefs-remember.md
+++ b/.changeset/late-chefs-remember.md
@@ -1,0 +1,8 @@
+---
+"rep-observer": major
+"@rep-observer/national": major
+"@rep-observer/state": major
+"@rep-observer/state-ca": major
+---
+
+Version sync, mark as major release since it's actually live now

--- a/data/national/package.json
+++ b/data/national/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rep-observer/national",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "National data parser and scraper for rep.observer"
+}

--- a/data/state/ca/package.json
+++ b/data/state/ca/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rep-observer/state-ca",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "California state legislature scripts for rep.observer"
+}

--- a/data/state/package.json
+++ b/data/state/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rep-observer/state",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Shared state data scripts for rep.observer"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "whattherepdoin",
-  "private": true,
+  "name": "rep-observer",
   "type": "module",
   "version": "0.2.1",
   "description": "Track what representatives vote on.",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - 'data/national'
+  - 'data/state'
+  - 'data/state/*'
+  - './'


### PR DESCRIPTION
the parsers also have versions that are separate from how the front end displays. this change enables pnpm workspaces so each state can record its changes separately